### PR TITLE
Remove warning on Chrome142 LNA flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,6 @@ Forwarding     https://3785c5ddc4b6.ngrok-free.app -> http://localhost:3000
 
 #### 6. Develop with HMR
 
-> ⚠️ Since the release of [Chrome 142](https://developer.chrome.com/blog/local-network-access#what_is_local_network_access), local network access on Chromium-based browser from website is **by default** blocked by an access permission prompt. As the widgets are being displayed within iframes, the prompt never appear. Hence, you won't see the iframe appear in ChatGPT.
-> In order to make it work, you need to go to `chrome://flags/#local-network-access-check` and disable the Local Network Access Checks.
-
 Now you can edit React components in `web` and see changes instantly:
 
 - Make changes to any component


### PR DESCRIPTION
This reverts commit 5a258c14ad563bb04ef1cd82a58e4f80ced0aedc.

OpenAI has added the `local-network-access *;` directive in their iFrames in dev mode. This warning is no longer required.