### PR TITLE
fix(ci): scaffold demo template non-interactively in sync workflow

### DIFF
--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -24,7 +24,7 @@ jobs:
         id: generate
         run: |
           find . -maxdepth 1 ! -name . ! -name .git -exec rm -rf {} +
-          npm create skybridge@latest .
+          npm create skybridge@latest -- . --yes --overwrite
           git checkout HEAD -- README.md .github
           VERSION=$(node -p "require('./package.json').dependencies.skybridge.match(/\d+\.\d+\.\d+/)[0]")
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The **Update Template** workflow (`.github/workflows/update-template.yml`) was failing. `create-skybridge` now prompts to choose between a **demo** and a **blank** template:

```
◆  Choose a template:
│  ● demo (starter code with tools and UI)
│  ○ blank (minimal boilerplate without tools)
```

In CI there's no TTY/input, so `npm create skybridge@latest .` hangs/fails on that prompt.

## Fix

```diff
- npm create skybridge@latest .
+ npm create skybridge@latest -- . --yes --overwrite
```

- **`--`** — npm intercepts bare `--yes`/`--help` for itself; the separator forwards the flags to `create-skybridge`. (Verified: without it, `npm` prints its own help instead of skybridge's.)
- **`--yes`** — runs non-interactively and **defaults to the `demo` template** (per the CLI source: `else if (yes) { template = "demo"; }`), which is what this repo has always tracked.
- **`--overwrite`** — scaffolds cleanly into the freshly-wiped directory; it preserves `.git`/`.github` (dot-dirs are skipped by the CLI's cleanup).

## Verification

Ran the exact command into a clean dir:

```
●  Copying demo template
◆  Copied demo template
●  Installing dependencies with npm
◆  Installed dependencies with npm
◆  All set!
```

No prompts, clean exit. Scaffolded output matches the current repo (mascot images, `src/server.ts`, `src/views/onboarding.tsx`, …) and `dependencies.skybridge` resolves to `^1.1.1`, so the existing `version=` extraction step still works.

Skills install and dependency install are left to the CLI (they run automatically under `--yes`), consistent with the committed `.agents/` and `skills-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)